### PR TITLE
configured compose script

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,10 @@
 services:
   postgres:
+    container_name: 'library-api-medium-db'
     image: 'postgres:latest'
     environment:
-      - 'POSTGRES_DB=mydatabase'
+      - 'POSTGRES_DB=library'
       - 'POSTGRES_PASSWORD=secret'
       - 'POSTGRES_USER=myuser'
     ports:
-      - '5432'
+      - '5432:5432'


### PR DESCRIPTION
Configured compose script to give the container a sensible name, and explicitly set a port mapping. By default, the compose script uses random ports and Spring will automatically connect to that random port, which makes working on multiple (micro) services nice, but can make using external tools like database clients a pain. Here I sacrifice the multiple service setup for ease of use with external tools since in this context, I am unlikely to run multiple services. I also like to name my database, and use some dummy values for db connection credentials that are consistent across my project for local development.